### PR TITLE
chore(frontend table-state): split player data into mutable and immutable

### DIFF
--- a/libs/frontend/shared/state/table/src/lib/effects/api-effects.ts
+++ b/libs/frontend/shared/state/table/src/lib/effects/api-effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { select, Store } from '@ngrx/store';
 import { catchError, concatMap, Observable, of, switchMap, take, tap, withLatestFrom } from 'rxjs';
-import { getCards, joinTable, leaveTable, preformTableAction } from '../actions/api.actions';
+import { getCards, joinTable, leaveTable, performTableAction } from '../actions/api.actions';
 import { PlayerApiService } from '../shared/data-access/player-api.service';
 import { AsyncRequestActions } from '../shared/util/action-util';
 import { selectPlayerId, selectTableId } from '../table.state';
@@ -43,7 +43,7 @@ export class TableStateApiEffects {
 
     requestPerformTableAction$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(preformTableAction.request),
+            ofType(performTableAction.request),
             concatMap((action) =>
                 of(action).pipe(
                     withLatestFrom(this.store.pipe(select(selectTableId)), this.store.pipe(select(selectPlayerId))),
@@ -54,7 +54,7 @@ export class TableStateApiEffects {
                     throw new Error('Missing required params');
                 }
 
-                return this.performApiRequest(preformTableAction, () =>
+                return this.performApiRequest(performTableAction, () =>
                     this.playerApiService.performAction(tableId, playerId, action.payload),
                 );
             }),
@@ -85,7 +85,7 @@ export class TableStateApiEffects {
     failedApiRequest$ = createEffect(
         () =>
             this.actions$.pipe(
-                ofType(...[getCards, joinTable, leaveTable, preformTableAction].map((action) => action.failure)),
+                ofType(...[getCards, joinTable, leaveTable, performTableAction].map((action) => action.failure)),
                 tap(({ payload }) => {
                     alert(payload);
                 }),

--- a/libs/frontend/shared/state/table/src/lib/table-state.facade.ts
+++ b/libs/frontend/shared/state/table/src/lib/table-state.facade.ts
@@ -2,17 +2,24 @@ import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import {
     Card,
+    ImmutablePublicPlayer,
     JoinTableRequest,
+    MutablePublicPlayer,
     PerformPlayerActionRequest,
     PlayerId,
-    PublicPlayer,
     Round,
     SeatId,
 } from '@poker-moons/shared/type';
 import { Observable } from 'rxjs';
-import { joinTable, leaveTable, preformTableAction } from './actions/api.actions';
-import { selectClientPlayer } from './table-state.selectors';
-import { selectActiveRound, selectCards, selectPlayerMap, selectSeatMap } from './table.state';
+import { joinTable, leaveTable, performTableAction } from './actions/api.actions';
+import { selectClientImmutablePlayer, selectClientMutablePlayer } from './table-state.selectors';
+import {
+    selectActiveRound,
+    selectCards,
+    selectImmutablePlayerMap,
+    selectMutablePlayerMap,
+    selectSeatMap,
+} from './table.state';
 
 @Injectable({ providedIn: 'root' })
 export class TableStateFacade {
@@ -30,10 +37,17 @@ export class TableStateFacade {
     }
 
     /**
-     * The map get the player from the state, while maintaining memoization
+     * The map of the players immutable data
      */
-    selectPlayerMap(): Observable<Record<PlayerId, PublicPlayer>> {
-        return this.store.pipe(select(selectPlayerMap));
+    selectImmutablePlayerMap(): Observable<Record<PlayerId, ImmutablePublicPlayer>> {
+        return this.store.pipe(select(selectImmutablePlayerMap));
+    }
+
+    /**
+     * The map of the players mutable data
+     */
+    selectMutablePlayerMap(): Observable<Record<PlayerId, MutablePublicPlayer>> {
+        return this.store.pipe(select(selectMutablePlayerMap));
     }
 
     /**
@@ -44,10 +58,17 @@ export class TableStateFacade {
     }
 
     /**
-     * Selects the player that is on this client
+     * Selects the immutable player that is on this client
      */
-    selectClientPlayer(): Observable<PublicPlayer | null> {
-        return this.store.pipe(select(selectClientPlayer));
+    selectClientImmutablePlayer(): Observable<ImmutablePublicPlayer | null> {
+        return this.store.pipe(select(selectClientImmutablePlayer));
+    }
+
+    /**
+     * Selects the immutable player that is on this client
+     */
+    selectClientMutablePlayer(): Observable<MutablePublicPlayer | null> {
+        return this.store.pipe(select(selectClientMutablePlayer));
     }
 
     /**
@@ -77,6 +98,6 @@ export class TableStateFacade {
      * Perform an action with the current client
      */
     performAction(dto: PerformPlayerActionRequest): void {
-        this.store.dispatch(preformTableAction.request({ payload: dto }));
+        this.store.dispatch(performTableAction.request({ payload: dto }));
     }
 }

--- a/libs/frontend/shared/state/table/src/lib/table-state.selectors.ts
+++ b/libs/frontend/shared/state/table/src/lib/table-state.selectors.ts
@@ -1,8 +1,14 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { selectPlayerId, selectPlayerMap, TABLE_STATE } from './table.state';
+import { selectImmutablePlayerMap, selectMutablePlayerMap, selectPlayerId, TABLE_STATE } from './table.state';
 
 export const selectState = createFeatureSelector(TABLE_STATE);
 
-export const selectClientPlayer = createSelector(selectPlayerMap, selectPlayerId, (playerMap, playerId) =>
+export const selectClientImmutablePlayer = createSelector(
+    selectImmutablePlayerMap,
+    selectPlayerId,
+    (playerMap, playerId) => (playerId === null ? null : playerMap[playerId]),
+);
+
+export const selectClientMutablePlayer = createSelector(selectMutablePlayerMap, selectPlayerId, (playerMap, playerId) =>
     playerId === null ? null : playerMap[playerId],
 );

--- a/libs/frontend/shared/state/table/src/lib/table.state.ts
+++ b/libs/frontend/shared/state/table/src/lib/table.state.ts
@@ -6,7 +6,8 @@ import { wsReducers } from './reducers/ws.reducers';
 export const TABLE_STATE = 'tableState';
 
 export const initialState: ClientTableState = {
-    playerMap: {},
+    immutablePlayerMap: {},
+    mutablePlayerMap: {},
     seatMap: {
         0: null,
         1: null,
@@ -36,5 +37,12 @@ export const storeFeature = createFeature({
     reducer: createReducer<ClientTableState>(initialState, ...wsReducers, ...apiReducers),
 });
 
-export const { selectActiveRound, selectCards, selectPlayerId, selectTableId, selectPlayerMap, selectSeatMap } =
-    storeFeature;
+export const {
+    selectActiveRound,
+    selectCards,
+    selectPlayerId,
+    selectTableId,
+    selectImmutablePlayerMap,
+    selectMutablePlayerMap,
+    selectSeatMap,
+} = storeFeature;

--- a/libs/shared/type/src/lib/player.ts
+++ b/libs/shared/type/src/lib/player.ts
@@ -58,3 +58,18 @@ export interface Player {
 }
 
 export type PublicPlayer = StrictOmit<Player, 'cards'>;
+/*
+ * We've split Player into `MutablePlayer` and `ImmutablePlayer`
+ * so that on the frontend we do a significant smaller amount of rerenders.
+ * As, updating `MutablePlayer` will only update components that depend on it
+ */
+
+/**
+ * Data on the player that is to be frequently updated during the game
+ */
+export type MutablePublicPlayer = Pick<PublicPlayer, 'stack' | 'status' | 'called'>;
+
+/**
+ * Data on the player that will stay the same during the game (mostly)
+ */
+export type ImmutablePublicPlayer = StrictOmit<PublicPlayer, keyof MutablePublicPlayer>;

--- a/libs/shared/type/src/lib/state.ts
+++ b/libs/shared/type/src/lib/state.ts
@@ -1,12 +1,18 @@
+import { ImmutablePublicPlayer } from '..';
 import type { Card } from './card';
-import type { PlayerId, PublicPlayer } from './player';
+import type { MutablePublicPlayer, PlayerId } from './player';
 import type { Table, TableId } from './table';
 
 export interface SharedTableState extends Pick<Table, 'seatMap' | 'roundCount' | 'activeRound'> {
     /**
-     * Project out the cards on the player
+     * Map of player data that will be frequently changed.
      */
-    playerMap: Record<PlayerId, PublicPlayer>;
+    mutablePlayerMap: Record<PlayerId, MutablePublicPlayer>;
+
+    /**
+     * Map of player data that will (for the most part) stay the same during the game
+     */
+    immutablePlayerMap: Record<PlayerId, ImmutablePublicPlayer>;
 }
 
 export interface ClientTableState extends SharedTableState {


### PR DESCRIPTION
## Proposed Changes

<!--- A brief description of the changes that this PR introduces. -->
I've realized memoization for the entire player map is going to be broken every single time an action is performed. So instead of that happening I've split it up so now only a map off mutable data will be broken. Which will cause less component re-renders.

## Linked Issue

<!--- The PR closes, fixes, or resolves an issue. -->

**resolves #46 **

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Merge Checklist

<!--- Checklist of items that should be addressed or acknowledged before merging. -->

-   [x] My code follows the code style of this project.
-   [x] All new and existing tests passed.
-   [x] Any dependent changes have been merged in downstream modules.
-   [x] I have provided inline technical documentation (tsdocs) where necessary.
-   [x] My change requires a change to the root documentation.
-   [x] I have updated the documentation accordingly.

## Deployment Notes

<!--- Any special deployment steps that this PR introduces -->
