### PR TITLE
chore(public-player): add cards to public player as it's required

### DIFF
--- a/libs/shared/testing/src/lib/player.ts
+++ b/libs/shared/testing/src/lib/player.ts
@@ -11,6 +11,7 @@ export function mockPublicPlayer(overrides: DeepPartial<PublicPlayer> = {}): Pub
         status: 'waiting',
         called: 100,
         seatId: 1,
+        cards: [],
     };
 
     return merge(publicPlayer, overrides);
@@ -32,6 +33,7 @@ export function mockMutablePublicPlayer(overrides: DeepPartial<MutablePublicPlay
         stack: 100,
         status: 'called',
         called: 10,
+        cards: [],
     };
 
     return merge(mutablePublicPlayer, overrides);

--- a/libs/shared/type/src/lib/player.ts
+++ b/libs/shared/type/src/lib/player.ts
@@ -57,7 +57,12 @@ export interface Player {
     cards: [Card, Card] | [];
 }
 
-export type PublicPlayer = StrictOmit<Player, 'cards'>;
+export interface PublicPlayer extends StrictOmit<Player, 'cards'> {
+    /**
+     * The cards of the player, If they have cards but they should be private then will be `[null, null]`
+     */
+    cards: Player['cards'] | [null, null];
+}
 /*
  * We've split Player into `MutablePlayer` and `ImmutablePlayer`
  * so that on the frontend we do a significant smaller amount of rerenders.
@@ -67,7 +72,7 @@ export type PublicPlayer = StrictOmit<Player, 'cards'>;
 /**
  * Data on the player that is to be frequently updated during the game
  */
-export type MutablePublicPlayer = Pick<PublicPlayer, 'stack' | 'status' | 'called'>;
+export type MutablePublicPlayer = Pick<PublicPlayer, 'stack' | 'status' | 'called' | 'cards'>;
 
 /**
  * Data on the player that will stay the same during the game (mostly)


### PR DESCRIPTION
## Proposed Changes

<!--- A brief description of the changes that this PR introduces. -->

We need to have cards on the public player when displaying the end of round battles. So we'll need to figure out the websocket payload aswell at some point. But we can figure that out later

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)

## Merge Checklist

<!--- Checklist of items that should be addressed or acknowledged before merging. -->

-   [x] My code follows the code style of this project.
-   [x] Any dependent changes have been merged in downstream modules.
-   [x] I have provided inline technical documentation (tsdocs) where necessary.
