### PR TITLE
Table state manager tests and updates

### DIFF
--- a/libs/backend/data-access/state/src/lib/mock-state/mock-state.service.spec.ts
+++ b/libs/backend/data-access/state/src/lib/mock-state/mock-state.service.spec.ts
@@ -42,7 +42,7 @@ describe('MockStateService', () => {
     });
 
     it('should be created', () => {
-        expect(service).toBeTruthy();
+        expect(service).toBeDefined();
     });
 
     describe('create', () => {

--- a/libs/backend/feature/table/src/lib/table-state-manager/table-state-manager.service.spec.ts
+++ b/libs/backend/feature/table/src/lib/table-state-manager/table-state-manager.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { TableStateManagerService } from './table-state-manager.service';
 import { BackendDataAccessStateModule } from '@poker-moons/backend/data-access/state';
+import { Player, ServerTableState, TableId } from '@poker-moons/shared/type';
 
 describe('TableStateManagerService', () => {
     let service: TableStateManagerService;
@@ -15,5 +16,120 @@ describe('TableStateManagerService', () => {
 
     it('should be defined', () => {
         expect(service).toBeDefined();
+    });
+
+    describe('create', () => {
+        it('should create an initial table state', async () => {
+            const id: TableId = await service.createNewTable('testTable');
+            const id2: TableId = await service.createNewTable('testTable2');
+            expect(id).toEqual('table_1');
+            expect(id2).toEqual('table_2');
+        });
+    });
+
+    describe('getState', () => {
+        it('should properly retrieve a table', async () => {
+            await service.createNewTable('testTable');
+            expect(await service.getTableById('table_1')).toEqual({
+                name: 'testTable',
+                seatMap: {
+                    0: undefined,
+                    1: undefined,
+                    2: undefined,
+                    3: undefined,
+                    4: undefined,
+                    5: undefined,
+                },
+                roundCount: 0,
+                activeRound: {
+                    pot: 0,
+                    toCall: 0,
+                    turnCount: 0,
+                    roundStatus: 'deal',
+                    activeSeat: null,
+                    dealerSeat: 0,
+                    smallBlind: 0,
+                    cards: [],
+                },
+                deck: [],
+                playerMap: {},
+            });
+        });
+
+        it('should get the correct table when multiple are created', async () => {
+            await service.createNewTable('testTable1');
+            await service.createNewTable('testTable2');
+            const table1 = await service.getTableById('table_1');
+            const table2 = await service.getTableById('table_2');
+            expect(table1.name).toEqual('testTable1');
+            expect(table2.name).toEqual('testTable2');
+        });
+    });
+
+    describe('delete', () => {
+        it('should delate a table', async () => {
+            await service.createNewTable('testTable');
+            await service.deleteTable('table_1');
+            expect(await service.getTableById('table_1')).toBeUndefined();
+        });
+    });
+
+    describe('update', () => {
+        it('should update a table - top level', async () => {
+            await service.createNewTable('testTable');
+            await service.updateTable('table_1', { name: "Your mom's dinner table" });
+            const table: ServerTableState = await service.getTableById('table_1');
+            expect(table.name).toEqual("Your mom's dinner table");
+        });
+
+        it('should update a table - addNewPlayerToTable', async () => {
+            await service.createNewTable('testTable');
+            const newPlayer: Player = {
+                id: `player_${'1'}`,
+                username: 'test',
+                img: 'test',
+                stack: 4,
+                status: `waiting`,
+                called: 0,
+                seatId: null,
+                cards: [],
+            };
+            await service.addNewPlayerToTable('table_1', newPlayer);
+            const table = await service.getTableById('table_1');
+            expect(table.playerMap['player_1']).toBeDefined();
+            expect(table.playerMap.player_1.username).toEqual('test');
+        });
+
+        it('should update a table - updateTablePlayer', async () => {
+            await service.createNewTable('testTable');
+            const newPlayer: Player = {
+                id: `player_${'1'}`,
+                username: 'test',
+                img: 'test',
+                stack: 4,
+                status: `waiting`,
+                called: 0,
+                seatId: null,
+                cards: [],
+            };
+            await service.addNewPlayerToTable('table_1', newPlayer);
+            await service.updateTablePlayer('table_1', 'player_1', { username: 'Jordan' });
+            const table: ServerTableState = await service.getTableById('table_1');
+            expect(table.playerMap.player_1.username).toEqual('Jordan');
+        });
+
+        it('should update a table - updateRound', async () => {
+            await service.createNewTable('testTable');
+            await service.updateRound('table_1', { pot: 69 }); //nice
+            const table: ServerTableState = await service.getTableById('table_1');
+            expect(table.activeRound.pot).toEqual(69);
+        });
+
+        it('should update a table - updateSeatMap', async () => {
+            await service.createNewTable('testTable');
+            await service.updateSeatMap('table_1', { 0: 'player_1' });
+            const table: ServerTableState = await service.getTableById('table_1');
+            expect(table.seatMap['0']).toEqual('player_1');
+        });
     });
 });

--- a/libs/backend/feature/table/src/lib/table-state-manager/table-state-manager.service.ts
+++ b/libs/backend/feature/table/src/lib/table-state-manager/table-state-manager.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { ServerTableState, TableId } from '@poker-moons/shared/type';
+import { Player, PlayerId, Round, SeatId, ServerTableState, TableId } from '@poker-moons/shared/type';
 import { GenericStateServiceImpl, STATE_SERVICE } from '@poker-moons/backend/data-access/state';
 
 const initialTableState: ServerTableState = {
@@ -58,6 +58,67 @@ export class TableStateManagerService {
      */
     public async updateTable(id: TableId, updatedTable: Partial<ServerTableState>): Promise<void> {
         return this.stateService.update(id, updatedTable);
+    }
+
+    /**
+     * Update an existing player at a table
+     * @param id The id of the table to update
+     * @param updatedPlayerId The id of the player to update
+     * @param updatedPlayer A partial of a Player containing the values to update
+     */
+    public async updateTablePlayer(
+        id: TableId,
+        updatedPlayerId: PlayerId,
+        updatedPlayer: Partial<Player>,
+    ): Promise<void> {
+        const tableToUpdate: ServerTableState = await this.stateService.getState(id);
+        tableToUpdate.playerMap[updatedPlayerId] = {
+            ...tableToUpdate.playerMap[updatedPlayerId],
+            ...updatedPlayer,
+        };
+        await this.stateService.update(id, tableToUpdate);
+    }
+
+    /**
+     * Add a new player to a table
+     * @param id The id of the table to add the player to
+     * @param newPlayer The new player object to add
+     */
+    public async addNewPlayerToTable(id: TableId, newPlayer: Player): Promise<void> {
+        const tableToUpdate: ServerTableState = await this.stateService.getState(id);
+        tableToUpdate.playerMap = {
+            ...tableToUpdate.playerMap,
+            [newPlayer.id]: newPlayer,
+        };
+        await this.stateService.update(id, tableToUpdate);
+    }
+
+    /**
+     * Update the round state of a table
+     * @param id The id of the table to update
+     * @param updatedRound A partial of a Round containing the values to update
+     */
+    public async updateRound(id: TableId, updatedRound: Partial<Round>): Promise<void> {
+        const tableToUpdate: ServerTableState = await this.stateService.getState(id);
+        tableToUpdate.activeRound = {
+            ...tableToUpdate.activeRound,
+            ...updatedRound,
+        };
+        await this.stateService.update(id, tableToUpdate);
+    }
+
+    /**
+     * Update the seat map of a table
+     * @param id The id of the table to update
+     * @param updatedSeatMap A partial of a complete seat map, containing that values to update
+     */
+    public async updateSeatMap(id: TableId, updatedSeatMap: Partial<Record<SeatId, PlayerId>>): Promise<void> {
+        const tableToUpdate: ServerTableState = await this.stateService.getState(id);
+        tableToUpdate.seatMap = {
+            ...tableToUpdate.seatMap,
+            ...updatedSeatMap,
+        };
+        await this.stateService.update(id, tableToUpdate);
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

- Add tests to the mock-state-service, table-state-manager-service
- Update table-state-manager-service to allow for updates to deep nested object (round, playerMap, seatMap)