### PR TITLE
fix(frontend websocket): add missing namespace config to frontend websocket connection

### DIFF
--- a/libs/backend/feature/table/src/lib/backend-feature-table.module.ts
+++ b/libs/backend/feature/table/src/lib/backend-feature-table.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { RouterModule } from '@nestjs/core';
+import { TableGatewayModule } from './shared/websocket/table-gateway.module';
 import { TableModule } from './table/table.module';
-import { TableStateManagerModule } from './table-state-manager/table-state-manager.module';
 
 @Module({
     imports: [
@@ -12,7 +12,7 @@ import { TableStateManagerModule } from './table-state-manager/table-state-manag
                 module: TableModule,
             },
         ]),
-        TableStateManagerModule,
+        TableGatewayModule,
     ],
 })
 export class BackendFeatureTableModule {}

--- a/libs/backend/feature/table/src/lib/shared/websocket/table-gateway.service.ts
+++ b/libs/backend/feature/table/src/lib/shared/websocket/table-gateway.service.ts
@@ -1,10 +1,10 @@
-import { TableEvent, TableId } from '@poker-moons/shared/type';
 import { Injectable } from '@nestjs/common';
+import { TableEvent, TableId } from '@poker-moons/shared/type';
 import { Server } from 'socket.io';
 
 @Injectable()
 export class TableGatewayService {
-    private server: Server;
+    private server!: Server;
 
     init(server: Server): void {
         this.server = server;

--- a/libs/backend/feature/table/src/lib/shared/websocket/table.gateway.ts
+++ b/libs/backend/feature/table/src/lib/shared/websocket/table.gateway.ts
@@ -1,3 +1,4 @@
+import { OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit, WebSocketGateway } from '@nestjs/websockets';
 import {
     ClientTableState,
     ImmutablePublicPlayer,
@@ -7,11 +8,10 @@ import {
     TABLE_NAMESPACE,
     TableId,
 } from '@poker-moons/shared/type';
-import { OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit, WebSocketGateway } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { TableGatewayService } from './table-gateway.service';
 import { TableStateManagerService } from '../../table-state-manager/table-state-manager.service';
 import { CustomLoggerService } from '@poker-moons/backend/utility';
+import { TableGatewayService } from './table-gateway.service';
 
 @WebSocketGateway({ namespace: TABLE_NAMESPACE })
 export class TableGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {

--- a/libs/frontend/shared/state/table/src/lib/shared/data-access/table-socket.service.ts
+++ b/libs/frontend/shared/state/table/src/lib/shared/data-access/table-socket.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, OnDestroy } from '@angular/core';
 import { NgEnvironment, NG_ENVIRONMENT } from '@poker-moons/frontend/shared/util/environment';
-import { TableEvent, TableId } from '@poker-moons/shared/type';
+import { TableEvent, TableId, TABLE_NAMESPACE } from '@poker-moons/shared/type';
 import { Observable } from 'rxjs';
 import { SocketClient } from '../util/socket-client';
 
@@ -16,7 +16,7 @@ export class TableSocketService implements OnDestroy {
      * @param tableId - The ID of the table the socket is being connected to
      */
     initialize(tableId: TableId): void {
-        this.socket = new SocketClient(this.env.api, {
+        this.socket = new SocketClient(this.env.api, TABLE_NAMESPACE, {
             query: { tableId },
             reconnection: true,
             transports: ['websocket', 'polling'],

--- a/libs/frontend/shared/state/table/src/lib/shared/util/socket-client.ts
+++ b/libs/frontend/shared/state/table/src/lib/shared/util/socket-client.ts
@@ -1,11 +1,13 @@
 import { Observable } from 'rxjs';
-import { io, ManagerOptions, Socket, SocketOptions } from 'socket.io-client';
+import { Manager, ManagerOptions, Socket, SocketOptions } from 'socket.io-client';
 
 export class SocketClient {
     private client: Socket;
 
-    constructor(uri: string, options: Partial<SocketOptions & ManagerOptions>) {
-        this.client = io(uri, options);
+    constructor(uri: string, namespace: string, options: Partial<SocketOptions & ManagerOptions>) {
+        const manager = new Manager(uri, options);
+
+        this.client = manager.socket(`/${namespace}`);
     }
 
     connect(): void {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@nestjs/common": "^8.2.0",
         "@nestjs/core": "^8.2.0",
         "@nestjs/platform-express": "^8.2.0",
+        "@nestjs/platform-socket.io": "^8.3.1",
         "@nestjs/websockets": "^8.2.3",
         "@ngrx/component-store": "^13.0.1",
         "@ngrx/effects": "^13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,6 +3164,14 @@
     multer "1.4.4"
     tslib "2.3.1"
 
+"@nestjs/platform-socket.io@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/platform-socket.io/-/platform-socket.io-8.3.1.tgz#8c1edc9b6407160c5d7ef98ca4d661b1e0b201c9"
+  integrity sha512-dXd3HhJQO9YkLL3HiwnPlHpcZyZfhviWCJ1+qF9cZcujTRzv2AAVL2Pn+dVAmdSEaPDZo3BYkcX3lG0fPqBOhw==
+  dependencies:
+    socket.io "4.4.1"
+    tslib "2.3.1"
+
 "@nestjs/schematics@^8.0.0":
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/@nestjs/schematics/-/schematics-8.0.6.tgz#925369ffc51e0d6d0284ad656cc0491e9f1e1cfd"
@@ -16917,7 +16925,7 @@ socket.io-parser@~4.1.1:
     "@socket.io/component-emitter" "~3.0.0"
     debug "~4.3.1"
 
-socket.io@^4.4.0:
+socket.io@4.4.1, socket.io@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.4.1.tgz#cd6de29e277a161d176832bb24f64ee045c56ab8"
   integrity sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==


### PR DESCRIPTION
## Proposed Changes
<!--- A brief description of the changes that this PR introduces. -->

I've realized once dylan's pr got merged for creating a table the websocket connection on the frontend wasn't working. I investigated and noticed. 

1. The TableGatewayModule is not exposed to the app.
2. The frontend socket client was not connecting based on `namespace` thus didn't connect.

This pr means the `onConnection` event actually works when you load a table

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
