### PR TITLE
fix(ci): update circleci/node to 5.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 orbs:
     aws-cli: circleci/aws-cli@1.4.1
-    node: circleci/node@5.0.0
+    node: circleci/node@5.0.1
 
 defaults: &defaults
     working_directory: ~/repo


### PR DESCRIPTION
## Proposed Changes
<!--- A brief description of the changes that this PR introduces. -->

Issue with current version circleci/node@5.0.0 is causing `yarn install` job to fail in the CI workflow. Upgrading to 5.0.1 which seems to fix the problem

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

