### PR TITLE
fix(winner-determiner): handle case where everyone folds

### DIFF
--- a/libs/backend/feature/table/src/lib/round/winner-determiner/util/rank.spec.ts
+++ b/libs/backend/feature/table/src/lib/round/winner-determiner/util/rank.spec.ts
@@ -103,6 +103,34 @@ describe('Rank Utility Functions', () => {
                 },
             ]);
         });
+
+        it('should return a win via fold case if only one player is passed in', () => {
+            const players: PlayerWithHand[] = [
+                {
+                    id: 'player_1',
+                    username: 'Levi',
+                    cards: [mockCard({ suit: 'clubs', rank: '4' }), mockCard({ suit: 'spades', rank: '4' })],
+                    hand: null,
+                    roundCalled: 100,
+                },
+            ];
+
+            const result = compareHands(players);
+
+            expect(result).toEqual<RankHandReponse[]>([
+                {
+                    player: {
+                        id: 'player_1',
+                        username: 'Levi',
+                        cards: [mockCard({ suit: 'clubs', rank: '4' }), mockCard({ suit: 'spades', rank: '4' })],
+                        hand: null,
+                        roundCalled: 100,
+                    },
+                    category: 'win via fold',
+                    score: 10000,
+                },
+            ]);
+        });
     });
 
     describe('rankHand', () => {

--- a/libs/backend/feature/table/src/lib/round/winner-determiner/winner-determiner.service.spec.ts
+++ b/libs/backend/feature/table/src/lib/round/winner-determiner/winner-determiner.service.spec.ts
@@ -5,7 +5,7 @@ import { createTestingModuleFactory, SpyObject } from '@trellisorg/nest-spectato
 import { TableGatewayService } from '../../shared/websocket/table-gateway.service';
 import { TableStateManagerService } from '../../table-state-manager/table-state-manager.service';
 import { PotManagerService } from '../pot-manager/pot-manager.service';
-import { playerMissingCards, roundMissingCards } from './winner-determiner.copy';
+import { playerMissingCards } from './winner-determiner.copy';
 import { WinnerDeterminerService } from './winner-determiner.service';
 
 describe('WinnerDeterminerService', () => {
@@ -82,8 +82,8 @@ describe('WinnerDeterminerService', () => {
 
     describe('determineWinner', () => {
         it('should emit single winner and update their stack in the state', async () => {
-            potManagerService.buildPot.mockReturnValueOnce(400).mockReturnValue(0);
-            potManagerService.splitPot.mockReturnValueOnce(200);
+            potManagerService.buildPot.mockReturnValueOnce(400).mockReturnValueOnce(0);
+            potManagerService.splitPot.mockReturnValueOnce(200).mockReturnValueOnce(200);
 
             await service.determineWinner(tableId, { [player1.id]: player1, [player3.id]: player3 }, round);
 
@@ -104,10 +104,14 @@ describe('WinnerDeterminerService', () => {
         });
 
         it('should emit multiple winners if there is a tie', async () => {
-            potManagerService.buildPot.mockReturnValueOnce(400).mockReturnValue(0);
-            potManagerService.splitPot.mockReturnValue(200);
+            potManagerService.buildPot.mockReturnValueOnce(400).mockReturnValueOnce(0);
+            potManagerService.splitPot.mockReturnValueOnce(200).mockReturnValueOnce(200);
 
-            await service.determineWinner(tableId, { [player1.id]: player1, [player2.id]: player2 }, round);
+            await service.determineWinner(
+                tableId,
+                { [player1.id]: { ...player1, roundCalled: 200 }, [player2.id]: player2 },
+                round,
+            );
 
             expect(tableGatewayService.emitTableEvent).toHaveBeenCalledWith(tableId, {
                 type: 'winner',
@@ -127,15 +131,15 @@ describe('WinnerDeterminerService', () => {
         });
 
         it('should emit multiple winners with varying amounts won if side pots have formed', async () => {
-            potManagerService.buildPot.mockReturnValueOnce(1600).mockReturnValueOnce(600).mockReturnValue(0);
+            potManagerService.buildPot.mockReturnValueOnce(1600).mockReturnValueOnce(600).mockReturnValueOnce(0);
             potManagerService.splitPot.mockReturnValueOnce(1000).mockReturnValueOnce(600);
 
             await service.determineWinner(
                 tableId,
                 {
-                    [player1.id]: player1,
-                    [player2.id]: player2,
-                    [player3.id]: player3,
+                    [player1.id]: { ...player1, roundCalled: 200 },
+                    [player2.id]: { ...player2, roundCalled: 200 },
+                    [player3.id]: { ...player3, roundCalled: 200 },
                     [player4.id]: player4,
                     [player5.id]: player5,
                 },
@@ -157,14 +161,6 @@ describe('WinnerDeterminerService', () => {
                     },
                 },
             });
-        });
-
-        it('should throw bad request exception if the table does not have 5 cards', async () => {
-            const invalidRound = mockRound({ pot: 1000, cards: [mockCard({ suit: 'clubs', rank: '10' })] });
-
-            await expect(
-                service.determineWinner(tableId, { [player1.id]: player1, [player2.id]: player2 }, invalidRound),
-            ).rejects.toThrow(new BadRequestException(roundMissingCards));
         });
 
         it('should throw bad request exception if any player does not have 2 cards', async () => {

--- a/libs/backend/feature/table/src/lib/round/winner-determiner/winner-determiner.types.ts
+++ b/libs/backend/feature/table/src/lib/round/winner-determiner/winner-determiner.types.ts
@@ -13,6 +13,7 @@ export const handCategory = [
     'two pairs',
     'pair',
     'high card',
+    'win via fold',
 ] as const;
 export type HandCategory = typeof handCategory[number];
 
@@ -20,9 +21,11 @@ export type PlayerWithHand = Pick<Player, 'id' | 'username' | 'roundCalled'> & {
     cards: [Card, Card];
 
     /**
-     * The five cards that make up the player's hand
+     * The five cards that make up the player's hand.
+     *
+     * Will be null only if the player has won due to everyone else folding.
      */
-    hand: Hand;
+    hand: Hand | null;
 };
 
 export interface RankHandReponse {


### PR DESCRIPTION
## Proposed Changes

Fixes the issue where the winner determiner was throwing a bad request exception in the case where someone wins after everyone else has folded.

Also fixes another issue I found where the pot wasn't being distributed correctly in certain cases.

## Linked Issue

<!--- The PR closes, fixes, or resolves an issue. -->

**fixes #184**

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Merge Checklist

<!--- Checklist of items that should be addressed or acknowledged before merging. -->

-   [x] My code follows the code style of this project.
-   [x] All new and existing tests passed.
-   [ ] Any dependent changes have been merged in downstream modules.
-   [x] I have provided inline technical documentation (tsdocs) where necessary.
-   [ ] My change requires a change to the root documentation.
-   [ ] I have updated the documentation accordingly.
