### PR TITLE
fix(frontend hud feature action-panel): issue where raise amount wouldn't reset after bidding cycle

### DIFF
--- a/libs/frontend/shared/ui/src/lib/form/slider-input/slider-input.component.html
+++ b/libs/frontend/shared/ui/src/lib/form/slider-input/slider-input.component.html
@@ -3,6 +3,6 @@
         [manualRefresh]="manualRefresh"
         [options]="options"
         [(value)]="_value"
-        (valueChange)="changed($event)"
+        (userChange)="changed($event)"
     ></ngx-slider>
 </div>

--- a/libs/frontend/shared/ui/src/lib/form/slider-input/slider-input.component.ts
+++ b/libs/frontend/shared/ui/src/lib/form/slider-input/slider-input.component.ts
@@ -1,4 +1,4 @@
-import { Options } from '@angular-slider/ngx-slider';
+import { ChangeContext, Options } from '@angular-slider/ngx-slider';
 import { Component, EventEmitter, Input } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
@@ -40,12 +40,14 @@ export class SliderInputComponent {
         hideLimitLabels: true,
         hidePointerLabels: true,
         showSelectionBar: true,
+        step: 25,
     };
 
     manualRefresh = new EventEmitter();
 
-    changed(value: number) {
-        this.control.setValue(value);
+    changed(context: ChangeContext) {
+        this.control.setValue(context.value);
+
         this.manualRefresh.emit();
     }
 }


### PR DESCRIPTION
## Proposed Changes
<!--- A brief description of the changes that this PR introduces. -->

Issue where the user's raise amount would carry on from the previous bidding cycle. Turned out to be an issue where the slider library `valueChange` was being called after the bidding cycle setting the form value when it shouldn't of been. I've changed it to `userChange` which seems only changes the value when the user clicks it. This seems to fix the issue.

## Linked Issue

<!--- The PR closes, fixes, or resolves an issue. -->

**resolves #212**

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Merge Checklist

<!--- Checklist of items that should be addressed or acknowledged before merging. -->

-   [ ] My code follows the code style of this project.
-   [ ] All new and existing tests passed.
-   [ ] Any dependent changes have been merged in downstream modules.
-   [ ] I have provided inline technical documentation (tsdocs) where necessary.
-   [ ] My change requires a change to the root documentation.
-   [ ] I have updated the documentation accordingly.

## Deployment Notes

<!--- Any special deployment steps that this PR introduces -->
