### PR TITLE
fix(round-manager): update player round called amount when auto-completing round

### DIFF
--- a/libs/backend/feature/table/src/lib/round/pot-manager/pot-manager.service.ts
+++ b/libs/backend/feature/table/src/lib/round/pot-manager/pot-manager.service.ts
@@ -1,38 +1,43 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { CustomLoggerService } from '@poker-moons/backend/utility';
 import { Player, TableId } from '@poker-moons/shared/type';
 import { TableStateManagerService } from '../../table-state-manager/table-state-manager.service';
 
 @Injectable()
 export class PotManagerService {
+    private logger = new CustomLoggerService(PotManagerService.name);
+
     constructor(private readonly tableStateManagerService: TableStateManagerService) {}
 
     /**
-     * Increments the active pot the designated amount
+     * @description Increments the active pot the designated amount.
      *
-     * @param tableId - the table the round is taking place on
-     * @param pot - the value of the pot in the current round
-     * @param amount - the amount to increment the pot by
+     * @param tableId - The table the round is taking place on.
+     * @param pot - The value of the pot in the current round.
+     * @param amount - The amount to increment the pot by.
      *
-     * @throws {BadRequestException} if the designated amount is not an integer
+     * @throws {BadRequestException} If the designated amount is not an integer.
      */
     async incrementPot(tableId: TableId, pot: number, amount: number): Promise<void> {
         if (!Number.isInteger(amount)) {
             throw new BadRequestException('The pot can only be incremented by integer amounts.');
         }
 
+        this.logger.debug(`Updating pot to ${pot + amount}`);
+
         await this.tableStateManagerService.updateRound(tableId, { pot: pot + amount });
     }
 
     /**
-     * Splits the pot between the designated number of players
+     * @description Splits the pot between the designated number of players.
      *
-     * Note: Often a pot cannot be equally split, but we've decided the
-     * leftover amount will just go to the house and not be distributed
+     * Note: Often a pot cannot be equally split, but we've decided the leftover amount will just go to the house
+     * and not be distributed.
      *
-     * @param pot - the value of the pot in the current round
-     * @param numPlayers - the number of players to split the pot between
+     * @param pot - The value of the pot in the current round.
+     * @param numPlayers - The number of players to split the pot between.
      *
-     * @returns the amount to distribute to each player and the amount leftover
+     * @returns The amount to distribute to each player and the amount leftover.
      */
     splitPot(pot: number, numPlayers: number): number {
         let amountToDistribute = 0;
@@ -47,13 +52,13 @@ export class PotManagerService {
     }
 
     /**
-     * Builds the pot amount to distribute to winners at the end of the round based
-     * on the amount each player has called, meaning the amount returned includes the main pot
-     * amount for the round as well as any side pots that may have formed
+     * @description Builds the pot amount to distribute to winners at the end of the round based on the amount each
+     * player has called, meaning the amount returned includes the main pot amount for the round as well as any
+     * side pots that may have formed.
      *
-     * @param players - the players that participated in the round
+     * @param players - The players that participated in the round.
      *
-     * @returns the pot amount to distribute amongst the winners
+     * @returns The pot amount to distribute amongst the winners.
      */
     buildPot(players: Pick<Player, 'roundCalled'>[]): number {
         let pot = 0;


### PR DESCRIPTION
## Proposed Changes

<!--- A brief description of the changes that this PR introduces. -->

Updates the player's round called amount in state during auto-round completion after an all-in scenario so that the winner determiner correctly builds the pot amount to distribute.

Also emits the updated value to the frontend, although it's probably not needed.

## Linked Issue

<!--- The PR closes, fixes, or resolves an issue. -->

**resolves #224**

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Merge Checklist

<!--- Checklist of items that should be addressed or acknowledged before merging. -->

-   [x] My code follows the code style of this project.
-   [x] All new and existing tests passed.
-   [ ] Any dependent changes have been merged in downstream modules.
-   [x] I have provided inline technical documentation (tsdocs) where necessary.
-   [ ] My change requires a change to the root documentation.
-   [ ] I have updated the documentation accordingly.
