### PR TITLE
fix(backend table): skip non-active players turns in future bidding cycles

### DIFF
--- a/libs/backend/feature/table/src/lib/player-action/handlers/raise/raise-action-handler.service.ts
+++ b/libs/backend/feature/table/src/lib/player-action/handlers/raise/raise-action-handler.service.ts
@@ -11,7 +11,7 @@ import { Either, isRight, left, right } from 'fp-ts/lib/Either';
 import { match, __ } from 'ts-pattern';
 import { PotManagerService } from '../../../round/pot-manager/pot-manager.service';
 import { RoundManagerService } from '../../../round/round-manager/round-manager.service';
-import { incrementSeat } from '../../../shared/util/round.util';
+import { findNextActiveSeatIfExists } from '../../../shared/util/round.util';
 import { TableGatewayService } from '../../../shared/websocket/table-gateway.service';
 import { TableStateManagerService } from '../../../table-state-manager/table-state-manager.service';
 import { validatePlayerTurn } from '../util/validate-player-turn';
@@ -54,11 +54,15 @@ export class RaiseActionHandlerService {
             const delta = action.right.action.amount - player.biddingCycleCalled;
 
             // Update the player's status, biddingCycleCalled amount, and stack in the server
-            await this.tableStateManagerService.updateTablePlayer(table.id, player.id, {
+            const playerUpdate: Partial<Player> = {
                 status: 'raised',
                 biddingCycleCalled: action.right.action.amount,
                 stack: player.stack - delta,
-            });
+            };
+            await this.tableStateManagerService.updateTablePlayer(table.id, player.id, playerUpdate);
+            table.playerMap[player.id] = { ...player, ...playerUpdate };
+
+            const playerStatuses = Object.values(table.playerMap).map((player) => player.status);
 
             // Increment the pot
             await this.potManagerService.incrementPot(table.id, table.activeRound.pot, delta);
@@ -69,7 +73,7 @@ export class RaiseActionHandlerService {
             });
 
             // Emit the PlayerTurnEvent to the frontend
-            const newActiveSeat = incrementSeat(table.activeRound.activeSeat, table.seatMap);
+            const newActiveSeat = findNextActiveSeatIfExists(table.activeRound.activeSeat, table, playerStatuses);
             this.tableGatewayService.emitTableEvent(table.id, {
                 type: 'turn',
                 playerId: player.id,
@@ -77,9 +81,6 @@ export class RaiseActionHandlerService {
                 newActiveSeatId: newActiveSeat,
                 bidAmount: delta,
             });
-
-            table.playerMap[player.id] = { ...player, status: 'raised' };
-            const playerStatuses = Object.values(table.playerMap).map((player) => player.status);
 
             return this.roundManagerService.startNextTurn(table, newActiveSeat, playerStatuses);
         } else {

--- a/libs/backend/feature/table/src/lib/round/round-manager/round-manager.service.ts
+++ b/libs/backend/feature/table/src/lib/round/round-manager/round-manager.service.ts
@@ -46,7 +46,7 @@ export class RoundManagerService {
      */
     async startNextTurn(
         table: ServerTableState,
-        nextActiveSeat: SeatId,
+        nextActiveSeat: SeatId | null,
         playerStatuses: PlayerStatus[],
     ): Promise<void> {
         // Re-fetch table, because race condition with player service
@@ -135,7 +135,7 @@ export class RoundManagerService {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 currentPlayerId: table.seatMap[table.activeRound.activeSeat!]!,
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                nextPlayerId: table.seatMap[nextActiveSeat]!,
+                nextPlayerId: table.seatMap[nextActiveSeat!]!,
             }),
         ]);
     }
@@ -151,7 +151,7 @@ export class RoundManagerService {
     async autoCompleteRound(
         tableId: TableId,
         playerMap: Record<PlayerId, Player>,
-        nextActiveSeat: SeatId,
+        nextActiveSeat: SeatId | null,
     ): Promise<void> {
         const updatedPlayerMap: Record<PlayerId, Player> = {};
 

--- a/libs/shared/type/src/lib/dto/table-ws.ts
+++ b/libs/shared/type/src/lib/dto/table-ws.ts
@@ -62,7 +62,7 @@ export interface PlayerTurnEvent extends GeneralTableEvent<'turn'> {
     /**
      * @description The new active seat after this turn.
      */
-    newActiveSeatId: SeatId;
+    newActiveSeatId: SeatId | null;
 }
 
 export interface WinnerWinnerChickenDinnerEvent extends GeneralTableEvent<'winner'> {


### PR DESCRIPTION
## Proposed Changes

Fixes backend table logic so that if a player folds, all-ins or goes out on the first (or previous) bidding cycle, they won't be required to provide in the future bidding cycles.

<!--- A brief description of the changes that this PR introduces. -->

## Linked Issue

<!--- The PR closes, fixes, or resolves an issue. -->

**resolves #253**

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Merge Checklist

<!--- Checklist of items that should be addressed or acknowledged before merging. -->

-   [x] My code follows the code style of this project.
-   [x] All new and existing tests passed.
-   [x] Any dependent changes have been merged in downstream modules.
-   [x] I have provided inline technical documentation (tsdocs) where necessary.
-   [ ] My change requires a change to the root documentation.
-   [ ] I have updated the documentation accordingly.

## Deployment Notes

<!--- Any special deployment steps that this PR introduces -->
