### PR TITLE
fix(round-manager): establish proper betting turn order

### DIFF
--- a/libs/backend/feature/table/src/lib/shared/util/round.util.spec.ts
+++ b/libs/backend/feature/table/src/lib/shared/util/round.util.spec.ts
@@ -1,6 +1,7 @@
 import { mockPlayer } from '@poker-moons/shared/testing';
 import { PlayerStatus } from '@poker-moons/shared/type';
 import {
+    determineStartingSeat,
     findNextActiveSeatIfExists,
     hasBiddingCycleEnded,
     hasEveryoneButOneFolded,
@@ -107,6 +108,20 @@ describe('Round Utils', () => {
 
         it('should skip empty seats when 5 is passed in', () => {
             expect(incrementSeat(5, { 2: 'player_2', 5: 'player_5' })).toEqual(2);
+        });
+    });
+
+    describe('determineStartingSeat', () => {
+        it('should return the dealer seat if the number of players is 2', () => {
+            expect(determineStartingSeat(0, { 0: 'player_0', 2: 'player_2' })).toEqual(0);
+        });
+
+        it('should return the dealer seat if the number of players is 3', () => {
+            expect(determineStartingSeat(2, { 0: 'player_0', 2: 'player_2', 5: 'player_5' })).toEqual(2);
+        });
+
+        it('should return the seat to the left of the big blind if there are more than 3 players', () => {
+            expect(determineStartingSeat(2, { 0: 'player_0', 2: 'player_2', 4: 'player_4', 5: 'player_5' })).toEqual(0);
         });
     });
 

--- a/libs/backend/feature/table/src/lib/shared/util/round.util.ts
+++ b/libs/backend/feature/table/src/lib/shared/util/round.util.ts
@@ -136,6 +136,26 @@ export function incrementSeat(seat: SeatId, seatMap: Partial<Record<SeatId, Play
 }
 
 /**
+ * @description Determines the starting seat when a round begins.
+ *
+ * @param dealerSeat - The seat of the dealer for the round.
+ * @param seatMap - The seat map for the round.
+ */
+export function determineStartingSeat(dealerSeat: SeatId, seatMap: Partial<Record<SeatId, PlayerId>>): SeatId {
+    const numPlayers = Object.values(seatMap).length;
+
+    // Pre-flop, the dealer always acts first in 2 or 3 player poker.
+    if (numPlayers === 2 || numPlayers === 3) {
+        return dealerSeat;
+    }
+
+    const smallBlindSeat = incrementSeat(dealerSeat, seatMap);
+    const bigBlindSeat = incrementSeat(smallBlindSeat, seatMap);
+
+    return incrementSeat(bigBlindSeat, seatMap);
+}
+
+/**
  * @description Provided the current round status, returns the next status in sequence.
  */
 export function incrementRoundStatus(status: RoundStatus): RoundStatus {


### PR DESCRIPTION
## Proposed Changes

<!--- A brief description of the changes that this PR introduces. -->

Updates the round manager so that the proper seat is set as active at the start of the round (left of the big blind) and then every subsequent betting cycle has the action starting with the player left of the dealer.

## Linked Issue

<!--- The PR closes, fixes, or resolves an issue. -->

**Resolves #229**

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Merge Checklist

<!--- Checklist of items that should be addressed or acknowledged before merging. -->

-   [x] My code follows the code style of this project.
-   [x] All new and existing tests passed.
-   [x] Any dependent changes have been merged in downstream modules.
-   [x] I have provided inline technical documentation (tsdocs) where necessary.
-   [ ] My change requires a change to the root documentation.
-   [ ] I have updated the documentation accordingly.
