### PR TITLE
Change kicker calculation to use the correct number of cards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 orbs:
     aws-cli: circleci/aws-cli@1.4.1
-    node: circleci/node@5.0.1
+    node: circleci/node@5.1.0
 
 defaults: &defaults
     working_directory: ~/repo
@@ -15,7 +15,6 @@ defaults: &defaults
     resource_class: arm.medium
 
 node_config: &node_config
-    install-yarn: true
     node-version: '14.18'
 
 set_env: &set_env
@@ -56,6 +55,9 @@ commands:
             - checkout
             - node/install:
                   <<: *node_config
+            - run:
+                  name: Install Yarn
+                  command: npm install --global yarn
             - run:
                   <<: *set_env
             - restore_cache:

--- a/libs/backend/feature/table/src/lib/round/winner-determiner/util/rank.spec.ts
+++ b/libs/backend/feature/table/src/lib/round/winner-determiner/util/rank.spec.ts
@@ -82,7 +82,7 @@ describe('Rank Utility Functions', () => {
                         roundCalled: 100,
                     },
                     category: 'three of a kind',
-                    score: 400 + 4 + 4 + 4 + 8,
+                    score: 400 + 4 + 4 + 4 + 8 + 2,
                 },
                 {
                     player: {
@@ -99,7 +99,7 @@ describe('Rank Utility Functions', () => {
                         roundCalled: 100,
                     },
                     category: 'high card',
-                    score: 100 + 14,
+                    score: 100 + 14 + 13 + 11 + 5 + 4,
                 },
             ]);
         });
@@ -154,7 +154,7 @@ describe('Rank Utility Functions', () => {
             expect(result).toEqual<RankHandReponse>({
                 player,
                 category: 'high card',
-                score: 100 + 12,
+                score: 100 + 12 + 8 + 7 + 4 + 2,
             });
         });
 
@@ -178,7 +178,7 @@ describe('Rank Utility Functions', () => {
             expect(result).toEqual<RankHandReponse>({
                 player,
                 category: 'pair',
-                score: 200 + 4 + 4 + 12,
+                score: 200 + 4 + 4 + 12 + 8 + 2,
             });
         });
 
@@ -226,7 +226,7 @@ describe('Rank Utility Functions', () => {
             expect(result).toEqual<RankHandReponse>({
                 player,
                 category: 'three of a kind',
-                score: 400 + 4 + 4 + 4 + 8,
+                score: 400 + 4 + 4 + 4 + 8 + 2,
             });
         });
 

--- a/libs/backend/feature/table/src/lib/round/winner-determiner/util/rank.ts
+++ b/libs/backend/feature/table/src/lib/round/winner-determiner/util/rank.ts
@@ -170,12 +170,12 @@ export function rankHand(player: PlayerWithHand): RankHandReponse {
             'high card': 5
         };
 
-        let kickersCount = kickersCountMap[category];
+        const kickersCount = kickersCountMap[category];
 
         // Find all eligible kickers (single, non-paired cards in players hand)
         // convert to numeric value of the rank, sort from highest to lowest, and then slice based
         // on how many kickers we need to take.
-        let kickers = Object.keys(ranks)
+        const kickers = Object.keys(ranks)
             .filter((key) => ranks[key as Rank] === 1)
             .map(Number)
             .sort((a, b) => b - a) // sort descending

--- a/libs/backend/feature/table/src/lib/round/winner-determiner/util/rank.ts
+++ b/libs/backend/feature/table/src/lib/round/winner-determiner/util/rank.ts
@@ -151,7 +151,9 @@ export function rankHand(player: PlayerWithHand): RankHandReponse {
             ) * 2;
     }
 
-    // Add the rank of the highest card to the score, which acts as the kicker to break ties
+    // Add the rank of the highest card(s) to the score, which act as the kicker(s) to break ties.
+    // Every hand must form 5 cards, so count the number of cards in the main hand and the excess
+    // become the kickers we have to consider.
     if (
         category === 'four of a kind' ||
         category === 'three of a kind' ||
@@ -159,12 +161,29 @@ export function rankHand(player: PlayerWithHand): RankHandReponse {
         category === 'pair' ||
         category === 'high card'
     ) {
-        score += Math.max(
-            ...Object.keys(ranks)
-                .filter((key) => ranks[key as Rank] === 1)
-                .map(Number),
-        );
+        // the number of kickers to consider for each category
+        const kickersCountMap: Record<string, number> = {
+            'four of a kind': 1,
+            'three of a kind': 2,
+            'two pairs': 1,
+            'pair': 3,
+            'high card': 5
+        };
+
+        let kickersCount = kickersCountMap[category];
+
+        // Find all eligible kickers (single, non-paired cards in players hand)
+        // convert to numeric value of the rank, sort from highest to lowest, and then slice based
+        // on how many kickers we need to take.
+        let kickers = Object.keys(ranks)
+            .filter((key) => ranks[key as Rank] === 1)
+            .map(Number)
+            .sort((a, b) => b - a) // sort descending
+            .slice(0, kickersCount); // take the top 'kickersCount' elements
+
+        score += kickers.reduce((a, b) => a + b, 0); // add all kickers to the score
     }
+
 
     return { player, category, score };
 }


### PR DESCRIPTION
We hit an edge case in this hand:

![image](https://github.com/broology/poker-moons/assets/2053862/9d87d001-5100-46e9-855b-f2e096723d14)

![image](https://github.com/broology/poker-moons/assets/2053862/eac513f5-b340-437e-8b98-4f068b3923b4)

pandaeight has K5, and his best hand is one pair, 66AK7
boarderboy has QT, and his best hand is one pair, 66AQT

The King out-kicks the queen, and thus is the higher hand.

Looking at the `rankHand` function, I notice the kicker logic currently considers all single cards in the players hand regardless of how many cards are currently used.

Poker hands must always form 5 cards, and we only consider kickers up to that point. I've adjusted the logic to use the correct amount of kickers based on the hand category.

There would be a more elegant way to determine the kicker count by counting how many cards we've already used (i.e. 4 for quads, 3 for trips) and subtracting from 5, but that seems unnecessarily clever. There's a fixed number of hand types and we know how many kickers are required for each.